### PR TITLE
PORT: Give Humans / Harpies / Dwarves RGB sliders

### DIFF
--- a/Content.Client/Lobby/UI/HumanoidProfileEditor.xaml
+++ b/Content.Client/Lobby/UI/HumanoidProfileEditor.xaml
@@ -112,7 +112,11 @@
                             <BoxContainer Margin="10" HorizontalExpand="True" Orientation="Vertical">
                                 <Label Text="{Loc 'humanoid-profile-editor-skin-color-label'}" />
                                 <Slider HorizontalExpand="True" Name="Skin" MinValue="0" MaxValue="100" Value="20" />
-                                <BoxContainer Name="RgbSkinColorContainer" Visible="False" Orientation="Vertical" HorizontalExpand="True"></BoxContainer>
+                                <BoxContainer Name="RgbSkinColorContainer" Visible="False" Orientation="Vertical" HorizontalExpand="True" />
+                                <!-- DEN: HumanAnimal skin color toggle -->
+                                <Button Name="SkinFurToggle" ToggleMode="True"
+                                    Text="{Loc 'humanoid-profile-editor-skin-toggle'}"
+                                    HorizontalAlignment="Right" />
                             </BoxContainer>
                             <!-- Hair -->
                             <BoxContainer Margin="10" Orientation="Horizontal">

--- a/Content.Client/Lobby/UI/HumanoidProfileEditor.xaml.cs
+++ b/Content.Client/Lobby/UI/HumanoidProfileEditor.xaml.cs
@@ -249,10 +249,8 @@ namespace Content.Client.Lobby.UI
             };
 
             RgbSkinColorContainer.AddChild(_rgbSkinColorSelector = new ColorSelectorSliders());
-            _rgbSkinColorSelector.OnColorChanged += _ =>
-            {
-                OnSkinColorOnValueChanged();
-            };
+            _rgbSkinColorSelector.OnColorChanged += _ => { OnSkinColorOnValueChanged(); };
+            SkinFurToggle.OnToggled += _ => { SetProfile(Profile, CharacterSlot); }; // DEN - Humanoid Skin Tones
 
             #endregion
 
@@ -792,9 +790,20 @@ namespace Content.Client.Lobby.UI
             PreviewDummy = _controller.LoadProfileEntity(Profile, JobOverride, ShowClothes.Pressed);
             SpriteView.SetEntity(PreviewDummy);
             _entManager.System<MetaDataSystem>().SetEntityName(PreviewDummy, Profile.Name);
+            UpdateSkinFurToggleVisibility(); // DEN - Humanoid Skin Tones
 
             // Check and set the dirty flag to enable the save/reset buttons as appropriate.
             SetDirty();
+        }
+
+        // DEN - Humanoid Skin Tones
+        private void UpdateSkinFurToggleVisibility()
+        {
+            if (Profile == null)
+                return;
+
+            var species = _prototypeManager.Index(Profile.Species);
+            SkinFurToggle.Visible = species.SkinColoration == HumanoidSkinColor.HumanAnimal;
         }
 
         /// <summary>
@@ -1257,6 +1266,29 @@ namespace Content.Client.Lobby.UI
                     break;
                 }
                 // End Frontier
+                // DEN - Humanoid Skin Tones
+                case HumanoidSkinColor.HumanAnimal:
+                    {
+                        SkinFurToggle.Visible = true;
+                        if (!SkinFurToggle.Pressed)
+                        {
+                            Skin.Visible = false;
+                            RgbSkinColorContainer.Visible = true;
+                            Markings.CurrentSkinColor = _rgbSkinColorSelector.Color;
+                            Profile = Profile.WithCharacterAppearance(Profile.Appearance.WithSkinColor(_rgbSkinColorSelector.Color));
+                        }
+                        else
+                        {
+                            Skin.Visible = true;
+                            RgbSkinColorContainer.Visible = false;
+                            var color = SkinColor.HumanSkinTone((int)Skin.Value);
+                            Markings.CurrentSkinColor = color;
+                            Profile = Profile.WithCharacterAppearance(Profile.Appearance.WithSkinColor(color));
+                        }
+
+                        break;
+                    }
+                    // End DEN
             }
 
             ReloadProfilePreview();
@@ -1542,6 +1574,27 @@ namespace Content.Client.Lobby.UI
                     break;
                 }
                 // End Frontier
+                // DEN - Humanoid Skin Tones
+                case HumanoidSkinColor.HumanAnimal:
+                    {
+                        SkinFurToggle.Visible = true;
+                        if (!SkinFurToggle.Pressed)
+                        {
+                            Skin.Visible = false;
+                            RgbSkinColorContainer.Visible = true;
+                            _rgbSkinColorSelector.Color = Profile.Appearance.SkinColor;
+
+                        }
+                        else
+                        {
+                            Skin.Visible = true;
+                            RgbSkinColorContainer.Visible = false;
+                            Skin.Value = SkinColor.HumanSkinToneFromColor(Profile.Appearance.SkinColor);
+
+                        }
+                        break;
+                    }
+                    // End DEN
             }
 
         }

--- a/Content.Shared/Humanoid/HumanoidCharacterAppearance.cs
+++ b/Content.Shared/Humanoid/HumanoidCharacterAppearance.cs
@@ -178,8 +178,7 @@ public sealed partial class HumanoidCharacterAppearance : ICharacterAppearance, 
         switch (skinType)
         {
             case HumanoidSkinColor.HumanToned:
-                var tone = Math.Round(Humanoid.SkinColor.HumanSkinToneFromColor(newSkinColor));
-                newSkinColor = Humanoid.SkinColor.HumanSkinTone((int)tone);
+                newSkinColor = ToHumanoidTone(newSkinColor);
                 break;
             case HumanoidSkinColor.Hues:
                 break;
@@ -193,6 +192,8 @@ public sealed partial class HumanoidCharacterAppearance : ICharacterAppearance, 
                 newSkinColor = Humanoid.SkinColor.ProportionalAnimalFurColor(newSkinColor);
                 break;
             case HumanoidSkinColor.HumanAnimal: // The Den - Humanoid Skin Tones
+                if (random.NextFloat(1.0f) > 0.5f) // 50% chance of being humanoid skin
+                    newSkinColor = ToHumanoidTone(newSkinColor);
                 break;
         }
 
@@ -209,6 +210,12 @@ public sealed partial class HumanoidCharacterAppearance : ICharacterAppearance, 
     public static Color ClampColor(Color color)
     {
         return new(color.RByte, color.GByte, color.BByte);
+    }
+
+    private static Color ToHumanoidTone(Color skinColor)
+    {
+        var tone = Math.Round(Humanoid.SkinColor.HumanSkinToneFromColor(skinColor));
+        return Humanoid.SkinColor.HumanSkinTone((int)tone);
     }
 
     public static HumanoidCharacterAppearance EnsureValid(HumanoidCharacterAppearance appearance, string species, Sex sex)

--- a/Content.Shared/Humanoid/HumanoidCharacterAppearance.cs
+++ b/Content.Shared/Humanoid/HumanoidCharacterAppearance.cs
@@ -121,6 +121,7 @@ public sealed partial class HumanoidCharacterAppearance : ICharacterAppearance, 
             HumanoidSkinColor.VoxFeathers => Humanoid.SkinColor.ClosestVoxColor(speciesPrototype.DefaultSkinTone),
             HumanoidSkinColor.AnimalFur => Humanoid.SkinColor.ClosestAnimalFurColor(speciesPrototype.DefaultSkinTone), // Einstein Engines - Tajaran
             HumanoidSkinColor.ShelegToned => Humanoid.SkinColor.ShelegSkinTone(speciesPrototype.DefaultHumanSkinTone), // Frontier
+            HumanoidSkinColor.HumanAnimal => speciesPrototype.DefaultSkinTone, // DEN - Humanoid Skin Tones
             _ => Humanoid.SkinColor.ValidHumanSkinTone,
         };
 
@@ -190,6 +191,8 @@ public sealed partial class HumanoidCharacterAppearance : ICharacterAppearance, 
                 break;
             case HumanoidSkinColor.AnimalFur: // Einstein Engines - Tajaran
                 newSkinColor = Humanoid.SkinColor.ProportionalAnimalFurColor(newSkinColor);
+                break;
+            case HumanoidSkinColor.HumanAnimal: // The Den - Humanoid Skin Tones
                 break;
         }
 

--- a/Content.Shared/Humanoid/SkinColor.cs
+++ b/Content.Shared/Humanoid/SkinColor.cs
@@ -298,6 +298,7 @@ public static class SkinColor
             HumanoidSkinColor.VoxFeathers => VerifyVoxFeathers(color),
             HumanoidSkinColor.ShelegToned => VerifyShelegSkinTone(color), // Frontier: Sheleg
             HumanoidSkinColor.AnimalFur => VerifyAnimalFur(color), // Einsetin Engines - Tajaran
+            HumanoidSkinColor.HumanAnimal => VerifyHues(color), // DEN - Humanoid Skin Tones
             _ => false,
         };
     }
@@ -312,6 +313,7 @@ public static class SkinColor
             HumanoidSkinColor.VoxFeathers => ClosestVoxColor(color),
             HumanoidSkinColor.ShelegToned => ValidShelegSkinTone, // Frontier: Sheleg
             HumanoidSkinColor.AnimalFur => ClosestAnimalFurColor(color), // Einsetin Engines - Tajaran
+            HumanoidSkinColor.HumanAnimal => ValidHumanSkinTone, // DEN - Humanoid Skin Tones
             _ => color
         };
     }
@@ -406,4 +408,5 @@ public enum HumanoidSkinColor : byte
     TintedHues, //This gives a color tint to a humanoid's skin (10% saturation with full hue range).
     ShelegToned, // Frontier: Like human toned, but with a different color range for blue
     AnimalFur, // Einstein Engines - limits coloration to more or less what earthen animals might have
+    HumanAnimal, // The Den - contains both human skin tones and RGB/HSV
 }

--- a/Resources/Locale/en-US/_DEN/preferences/ui/humanoid-profile-editor.ftl
+++ b/Resources/Locale/en-US/_DEN/preferences/ui/humanoid-profile-editor.ftl
@@ -1,0 +1,1 @@
+humanoid-profile-editor-skin-toggle = Humanoid Skin Tones

--- a/Resources/Prototypes/Species/dwarf.yml
+++ b/Resources/Prototypes/Species/dwarf.yml
@@ -6,4 +6,4 @@
   sprites: MobHumanSprites
   markingLimits: MobHumanMarkingLimits
   dollPrototype: MobDwarfDummy
-  skinColoration: HumanToned
+  skinColoration: HumanAnimal # DEN

--- a/Resources/Prototypes/Species/human.yml
+++ b/Resources/Prototypes/Species/human.yml
@@ -6,7 +6,7 @@
   sprites: MobHumanSprites
   markingLimits: MobHumanMarkingLimits
   dollPrototype: MobHumanDummy
-  skinColoration: HumanToned
+  skinColoration: HumanAnimal # DEN
 
 # The lack of a layer means that
 # this person cannot have round-start anything

--- a/Resources/Prototypes/_DV/Species/harpy.yml
+++ b/Resources/Prototypes/_DV/Species/harpy.yml
@@ -6,7 +6,7 @@
   sprites: MobHarpySprites
   markingLimits: MobHarpyMarkingLimits
   dollPrototype: MobHarpyDummy
-  skinColoration: HumanToned
+  skinColoration: HumanAnimal # DEN
 
 - type: speciesBaseSprites
   id: MobHarpySprites


### PR DESCRIPTION
## About the PR
This PR ports the HumanAnimal skin color type from Salvation (partial port of TheDenSS14/TheDen#336 ) and gives it to humans, harpies, and dwarves. This allows those species to toggle between RGB skin color sliders and the humanoid skin slider.

## Why / Balance
I would like to bring human-hybrids over here.

## Technical details
Addition of the new HumanAnimal skin color type and its implementation in the UI and profile generator. Species YML changes.

## How to test
1. Enter the lobby.
2. Create a character that is a Human, Harpy, or Dwarf.
3. Use the skin sliders.
4. Click the "Humanoid Skin Tones" button to toggle to the other skin color type.
5. Use those, too.

## Media
<img width="908" height="446" alt="image" src="https://github.com/user-attachments/assets/1ecdb95d-7940-426a-9600-7466f5c694f6" />
<img width="907" height="354" alt="image" src="https://github.com/user-attachments/assets/9fc86a77-c322-41c2-a4b9-021bd03fe35b" />

## Requirements
- [x] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).

## Breaking changes
Not currently...?

**Changelog**
:cl:
- add: Humans, harpies, and dwarves can now toggle between humanoid skin tones and RGB color sliders.