### PR TITLE
Return of vending machine dubious goods

### DIFF
--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/chapel.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/chapel.yml
@@ -47,9 +47,16 @@
     DrinkWineBottleFull: 1
     ToyFigurineChaplain: 1
     ClothingNeckScarfStripedBlack: 3
+    BibleNanoTrasen: 3
+    BibleCommunistManifesto: 3
+    BibleDruid: 3
+    BibleTanakh: 3
   emaggedInventory:
     WoodenStake: 6 # Frontier
     ClothingOuterRobesCult: 3
     ClothingHeadHatHoodCulthood: 3
     ClothingShoesCult: 6
     BedsheetCult: 4
+    BibleNecronomicon: 2 # Damnation
+    BibleSatanic: 2 # Damnation
+    

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/chemvend.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/chemvend.yml
@@ -62,4 +62,4 @@
     ChemistryBottleMuteToxin: 3
     ChemistryBottleLead: 2
     ChemistryBottleToxin: 1
-
+    ChemicalPayload: 2 # Damnation

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/cigs.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/cigs.yml
@@ -14,6 +14,8 @@
     CheapLighter: 4
     Lighter: 2
     FlippoLighter: 2
+    DiscountDanLighter: 3
+    WaffleCoFlippo: 3
     NFAshtray: 4
     SmokingPipe: 4 # Frontier
     TobaccoPouchBrownFilled: 2 # Frontier
@@ -25,3 +27,13 @@
     GroundTobacco: 3
     CigarGold: 2
     Igniter: 1
+    NanotrasenFlippo: 2
+    HonkCoFlippo: 2
+    DonkcoLighter: 2
+  emaggedInventory: # Damnation, GIVE US OUR ILLEGAL SMOKES
+    CigarPlatinumCase: 1 
+    CigPackSyndicate: 1
+    SyndicateFlippo: 2
+    CybersunFlippo: 2
+    InterdyneFlippo: 2
+    

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/magivend.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/magivend.yml
@@ -10,6 +10,14 @@
     ClothingOuterWizardViolet: 3
     ClothingHeadHelmetWizardHelm: 3
     ClothingShoesWizard: 9
+
+  contrabandInventory: # Damnation
+    MagicalLamp: 1
+    FireballZine: 1
+    KnockZine: 1
+    BlinkZine: 1
+  emaggedInventory: #Damnation
+    ClothingOuterHardsuitWizard: 1
     #TODO:
     #only missing staff
     #and if wizarditis reagent when hacked if we want this.

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/magivend.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/magivend.yml
@@ -14,8 +14,8 @@
   contrabandInventory: # Damnation
     MagicalLamp: 1
     FireballZine: 1
-    KnockZine: 1
-    #BlinkZine: 1 #removed at server owner's request
+    #KnockZine: 1 #removed at server owner's request
+    BlinkZine: 1 
   emaggedInventory: #Damnation
     ClothingOuterHardsuitWizard: 1
     #TODO:

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/magivend.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/magivend.yml
@@ -15,7 +15,7 @@
     MagicalLamp: 1
     FireballZine: 1
     KnockZine: 1
-    BlinkZine: 1
+    #BlinkZine: 1 #removed at server owner's request
   emaggedInventory: #Damnation
     ClothingOuterHardsuitWizard: 1
     #TODO:

--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -1,5 +1,6 @@
 # TODO: make more categories
-# Guns
+# DAMNATION NOTE: Added regions to contravend for future ease in overhauling
+#region Guns
 
 - type: listing
   abstract: true # Frontier: moved to _NF uplink catalog
@@ -247,7 +248,7 @@
   categories:
   - UplinkWeaponry
 
-# Explosives
+#region Explosives
 
 # - type: listing # Frontier
   # id: UplinkExplosiveGrenade
@@ -493,7 +494,7 @@
   categories:
     - UplinkExplosives
 
-# Ammo
+#region Ammo
 
 - type: listing
   abstract: true # Frontier: moved to _NF uplink catalog
@@ -626,7 +627,7 @@
         components:
           - SurplusBundle
 
-#Chemicals
+#region Chemicals
 
 - type: listing
   id: UplinkHypopen
@@ -787,7 +788,7 @@
         components:
           - SurplusBundle
 
-# Deception
+#region Deception
 
 - type: listing
   id: UplinkAgentIDCard
@@ -936,7 +937,7 @@
   # categories:
   # - UplinkDeception
 
-# Disruption
+#region Disruption
 
 - type: listing
   id: UplinkAccessBreaker
@@ -1205,7 +1206,7 @@
   categories:
   - UplinkDisruption
 
-# Allies
+#region Allies
 
 - type: listing
   id: UplinkHoloparaKit
@@ -1363,7 +1364,7 @@
   - !type:ListingLimitedStockCondition
     stock: 1
 
-# Implants
+#region Implants
 
 - type: listing
   id: UplinkStorageImplanter
@@ -1562,7 +1563,7 @@
   - UplinkImplants
 
 
-# Wearables
+#region Wearables
 
 - type: listing
   id: UplinkJetpack
@@ -1796,7 +1797,7 @@
   categories:
     - UplinkWearables
 
- # Pointless
+ #region Pointless
 
 - type: listing
   id: UplinkBarberScissors
@@ -1965,7 +1966,7 @@
   - !type:ListingLimitedStockCondition
     stock: 3
 
-# Job Specific
+#region Job Specific
 
 - type: listing
   id: uplinkGatfruitSeeds

--- a/Resources/Prototypes/Entities/Objects/Specific/Chapel/bibles.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Chapel/bibles.yml
@@ -82,6 +82,8 @@
     sprite: Objects/Specific/Chapel/necronomicon.rsi
   - type: Item
     sprite: Objects/Specific/Chapel/necronomicon.rsi
+  - type: StaticPrice # Damnation
+    price: 90  # Damnation
 
 - type: entity
   parent: BaseAction

--- a/Resources/Prototypes/Entities/Objects/Tools/lighters.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/lighters.yml
@@ -334,6 +334,8 @@
     netsync: false
     radius: 2
     color: green
+  - type: StaticPrice # Damnation
+    price: 75 # Damnation
 
 - type: entity
   parent: Lighter
@@ -389,6 +391,8 @@
         - ReagentId: WeldingFuel
           Quantity: 3
         maxVol: 3
+  - type: StaticPrice # Damnation
+    price: 5 # Damnation
 
 - type: entity
   parent: [BaseBrandedLighter, BaseC3SyndicateContraband] # Frontier: BaseSyndicateContraband<BaseC3SyndicateContraband
@@ -409,6 +413,8 @@
     netsync: false
     radius: 2
     color: magenta
+  - type: StaticPrice # Damnation
+    price: 75 # Damnation
 
 - type: entity
   parent: [BaseBrandedLighter, BaseC3SyndicateContraband] # Frontier: BaseSyndicateContraband<BaseC3SyndicateContraband
@@ -433,6 +439,8 @@
     netsync: false
     radius: 2
     color: cyan
+  - type: StaticPrice # Damnation
+    price: 75 # Damnation
 
 - type: entity
   parent: [BaseBrandedLighter]
@@ -463,6 +471,8 @@
         - ReagentId: Plasma
           Quantity: 10
         maxVol: 10
+  - type: StaticPrice # Damnation
+    price: 50 # Damnation
 
 - type: entity
   parent: [BaseBrandedLighter, BaseCentcommContraband]
@@ -549,6 +559,8 @@
     netsync: false
     radius: 2
     color: brown
+  - type: StaticPrice # Damnation
+    price: 50 # Damnation
 
 - type: entity
   parent: [BaseBrandedLighter]
@@ -594,6 +606,8 @@
     netsync: false
     radius: 2
     color: yellow
+  - type: StaticPrice # Damnation
+    price: 50 # Damnation
 
 - type: entity
   parent: [BaseBrandedLighter]
@@ -640,3 +654,5 @@
     netsync: false
     radius: 2
     color: orange
+  - type: StaticPrice # Damnation
+    price: 50 # Damnation

--- a/Resources/Prototypes/_AS/Loadouts/jobs/Mercenary/belts.yml
+++ b/Resources/Prototypes/_AS/Loadouts/jobs/Mercenary/belts.yml
@@ -26,3 +26,9 @@
   equipment:
     belt: MedicRigMedical
 
+- type: loadout #Damnation
+  id: ClothingBeltSecurityWebbing
+  name: security carrier
+  price: 500
+  equipment:
+    belt: ClothingBeltMercenaryWebbing

--- a/Resources/Prototypes/_Damnation/Entities/Objects/Magic/books.yml
+++ b/Resources/Prototypes/_Damnation/Entities/Objects/Magic/books.yml
@@ -25,30 +25,30 @@
     - type: StaticPrice # Damnation
       price: 250 # Damnation
 
-- type: entity
-  id: KnockZine
-  name: knock for dummies
-  parent: BaseSpellbook
-  description: A thick "zine" describing the simple basics of opening doors through expectedly complicated thaumaturgy.
-  components:
-    - type: Sprite
-      sprite: Objects/Misc/books.rsi
-      layers:
-      - state: paper
-      - state: cover_strong
-        color: "#117045"
-      - state: decor_wingette_circle
-        color: gold
-      - state: icon_magic_knock
-      - state: detail_rivets
-        color: gold
-      - state: detail_bookmark
-        color: "#98c495"
-    - type: Spellbook
-      spellActions:
-        ActionKnock: 3
-    - type: StaticPrice # Damnation
-      price: 250 # Damnation
+#- type: entity
+  #id: KnockZine #Damnation; removed at server owner's request
+  #name: knock for dummies
+  #parent: BaseSpellbook
+  #description: A thick "zine" describing the simple basics of opening doors through expectedly complicated thaumaturgy.
+  #components:
+    #- type: Sprite
+      #sprite: Objects/Misc/books.rsi
+      #layers:
+      #- state: paper
+      #- state: cover_strong
+        #color: "#117045"
+      #- state: decor_wingette_circle
+        #color: gold
+      #- state: icon_magic_knock
+      #- state: detail_rivets
+        #color: gold
+      #- state: detail_bookmark
+        #color: "#98c495"
+    #- type: Spellbook
+      #pellActions:
+        #ActionKnock: 3
+    #- type: StaticPrice # Damnation
+      #price: 250 # Damnation
 
 - type: entity
   id: BlinkZine

--- a/Resources/Prototypes/_Damnation/Entities/Objects/Magic/books.yml
+++ b/Resources/Prototypes/_Damnation/Entities/Objects/Magic/books.yml
@@ -1,0 +1,75 @@
+- type: entity
+  id: FireballZine
+  name: fireball for dummies
+  parent: BaseSpellbook
+  description: A thick "zine" describing the simple basics of throwing a fireball through expectedly complicated thaumaturgy.
+  components:
+    - type: Sprite
+      sprite: Objects/Misc/books.rsi
+      layers:
+      - state: paper
+      - state: cover_old
+        color: "#ba5a14"
+      - state: decor_wingette_circle
+        color: gold
+      - state: detail_rivets
+        color: gold
+      - state: detail_bookmark
+        color: "#e89b3c"
+      - state: overlay_blood
+      - state: icon_magic_fireball
+        shader: unshaded
+    - type: Spellbook
+      spellActions:
+        ActionFireball: 5
+    - type: StaticPrice # Damnation
+      price: 250 # Damnation
+
+- type: entity
+  id: KnockZine
+  name: knock for dummies
+  parent: BaseSpellbook
+  description: A thick "zine" describing the simple basics of opening doors through expectedly complicated thaumaturgy.
+  components:
+    - type: Sprite
+      sprite: Objects/Misc/books.rsi
+      layers:
+      - state: paper
+      - state: cover_strong
+        color: "#117045"
+      - state: decor_wingette_circle
+        color: gold
+      - state: icon_magic_knock
+      - state: detail_rivets
+        color: gold
+      - state: detail_bookmark
+        color: "#98c495"
+    - type: Spellbook
+      spellActions:
+        ActionKnock: 3
+    - type: StaticPrice # Damnation
+      price: 250 # Damnation
+
+- type: entity
+  id: BlinkZine
+  name: blink for dummies
+  parent: BaseSpellbook
+  description: A thick "zine" describing the simple basics of moving a distance through expectedly complicated thaumaturgy.
+  components:
+    - type: Sprite
+      sprite: Objects/Misc/books.rsi
+      layers:
+      - state: paper
+      - state: cover_old
+        color: "#657e9c"
+      - state: icon_text3
+      - state: decor_wingette_circle
+        color: gold
+      - state: icon_magic
+      - state: detail_rivets
+        color: gold
+    - type: Spellbook
+      spellActions:
+        ActionBlink: 3
+    - type: StaticPrice # Damnation
+      price: 250 # Damnation

--- a/Resources/Prototypes/_NF/Catalog/VendingMachines/Inventories/bountyvend.yml
+++ b/Resources/Prototypes/_NF/Catalog/VendingMachines/Inventories/bountyvend.yml
@@ -33,6 +33,7 @@
     ClothingBackpackDuffelMercenary: 3
     ClothingBackpackSatchelMercenary: 3
     ClothingBackpackMessengerMercenary: 3
+    ClothingBeltSecurityWebbing: 3 # Damnation
 # Private Security
     ClothingHeadHatBeretSecurity: 3
     ClothingEyesGlassesSunglasses: 3
@@ -100,6 +101,7 @@
     ClothingBackpackDuffelMercenary: 3
     ClothingBackpackSatchelMercenary: 3
     ClothingBackpackMessengerMercenary: 3
+    ClothingBeltSecurityWebbing: 3 # Damnation
 # Private Security
     ClothingHeadHatBeretSecurity: 4294967295 # Infinite
     ClothingEyesGlassesSunglasses: 4294967295 # Infinite


### PR DESCRIPTION
re-adds criminal mischief to a handful of vending machine manager-wire and emag interactions. First pass of however many it takes to breathe some additional life back into vending machine catalogues.

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR

Adds security carrier to merc belt options + bounty vend catalogue. 
Adds branded lighters to shadycigs vend. Adds syndicate/interdyne/cybersun lighters to emag interactions, and re-adds interdyne herbals to the emag interactions. 
Adds holy book variants to pietyvend's catalogue & manager wire. Adds necronomicon to emag interaction.
Adds markdown to traitor uplink code for ease of browsing + future overhauls to contravend.
Adds 3 limited-charge spellbooks to the magivend's manager wire menu, and the wizard hardsuit as an emag interaction.
Adds 2 chemical payloads to the chemvend's manager wire.


## Why / Balance
A number of upstream changes from the merge removed a lot of fun or functional items from manager wire/emagging interactions used on vending machines- boiling it by and large down to just cosmetics that can be obtained through normal means, and further rendering the emag dead weight. More emag interactions means more use for the tool, and more creative uses from players wanting TO use it as a result.

In addition, bringing functional magic items into the fold adds more color/weirdness to the sector- upstream frontier is currently considering a total from the ground up rework for the wizard faction/uiv, including a number of functional items, which would be a boon to damnation as a whole.

## How to test
spawn in, grab your tools/an emag, and start hacking the piety/magi/shadycigs/chem vends for holy/unholy/magic books, cigs and branded lighters, and payloads for assuredly legal things.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- add: Added multiple hacking & emag interactions to the piety vend, shadycigs vend, magivend, and chemvend
- add: Added magical zines from the Wizard Federation's annual art fair to the magivend, with limited spells. 
- add: Added security carriers to the bounty vend as another belt-slot option. 
- tweak: Changed contents of aforementioned vending machines to accomodate, including pricing to new or returning items.


