### PR TITLE
Weapon/Weapon Tier & Spawn adjustments

### DIFF
--- a/Resources/Prototypes/_AS/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/_AS/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -123,7 +123,7 @@
     maxAngle: 6.2
     angleIncrease: 0.25
     angleDecay: 1
-    fireRate: 4
+    fireRate: 3 #changed
     selectedMode: SemiAuto
     availableModes:
     - SemiAuto
@@ -142,11 +142,10 @@
     maxAngle: 5.5
     angleIncrease: 0.2
     angleDecay: 0.8
-    fireRate: 4.3
+    fireRate: 3.5 #Damnation, changed
     selectedMode: SemiAuto
     availableModes:
-    - SemiAuto
-    - Burst
+    - SemiAuto #Damnation, removed burst
   - type: ProjectileBatteryAmmoProvider
     proto: ASLasBoltMedium
     fireCost: 50
@@ -183,7 +182,7 @@
 # endregion - battery rifles | Aurora Song
 # region - battery pistols | Aurora Song
 - type: entity
-  name: Basin Las Pistol
+  name: Basin Las Pistol #Las pistol previously with bursts did enough damage in a few seconds to put someone into full death via high-cap power cells; these come with the gun's weapon case spawn, hyper cells on direct hits easily put someone over 400 damage in barely any more time. Changed for balance.
   parent: [ ASWeaponFrameBatteryPistolDualOptics, BaseC1Contraband ]
   suffix: LasPistol
   id: ASWeaponBasinLasPistol
@@ -191,8 +190,7 @@
   components:
   - type: Gun
     availableModes:
-    - SemiAuto
-    - Burst
+    - SemiAuto #Damnation, removed burst
   - type: Sprite
     sprite: _AS/Objects/Weapons/Guns/Pistols/basin.rsi
     layers:

--- a/Resources/Prototypes/_NF/Catalog/Fills/Items/weapon_cases_expedition.yml
+++ b/Resources/Prototypes/_NF/Catalog/Fills/Items/weapon_cases_expedition.yml
@@ -338,7 +338,7 @@
   components:
   - type: StorageFill
     contents:
-    - id: NFWeaponRifleAssaultSmExpedition # Corrected to be using the expedition version of the gun | Aurora Song
+    - id: NFWeaponRifleAssaultSm
       amount: 1
     - id: NFMagazineRifle30
       amount: 2
@@ -496,6 +496,17 @@
 #    contents:
 #    - id: NFWeaponEnergyRifleTemperatureExpedition
 #      amount: 1
+
+- type: entity
+  parent: WeaponCaseHeavy
+  id: WeaponCaseLongEnergyLightMachineGunTurboExpedition
+  suffix: Dungeon, Turbo Laser Mk3
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: StorageFill
+    contents:
+    - id: NFWeaponEnergyLightMachineGunTurbo
+      amount: 1
 
 #region Sniper
 - type: entity

--- a/Resources/Prototypes/_NF/Entities/Markers/Spawners/Random/dungeon_items_weapons.yml
+++ b/Resources/Prototypes/_NF/Entities/Markers/Spawners/Random/dungeon_items_weapons.yml
@@ -86,10 +86,11 @@
   - type: RandomSpawner
     prototypes:
     - PlasteelArmingSword
-    - Cutlass
     - Claymore
     - Truncheon
     - WeaponCaseShortEnergyDaggerExpedition
+    - Cutlass 
+    - Rapier #moved to tier 3, lack of broad wideswing makes it slightly more niche use
     chance: 1.0
     offset: 0.0
     rarePrototypes:
@@ -118,7 +119,6 @@
     - Katana
     - CaptainSabre
     - SecBreachingHammer
-    - Rapier
     chance: 1.0
     offset: 0.0
     rarePrototypes:
@@ -180,11 +180,14 @@
     - WeaponCaseLongRepeaterExpedition
     - WeaponCaseLongSniperCeremonialExpedition
     - WeaponCaseShortSvalinnExpedition # Svalinn to T1 | Aurora Song
+    - WeaponCaseLongGestioExpedition # moved to T1, it's a roundstart weapon
+    - WeaponCaseLongWeaponRifleNovaliteC1Expedition # moved to T1, it's a roundstart weapon
+    - WeaponCaseShortLaserGunExpedition #moved to T1, basic/roundstart
     chance: 1.0
     offset: 0.0
     rarePrototypes:
     - SpawnDungeonLootGunT2
-    rareChance: 0.05
+    rareChance: 0.2 #changed
 
 #region guns T2
 - type: entity
@@ -205,24 +208,20 @@
       color: red
   - type: RandomSpawner
     prototypes:
-    - WeaponCaseLongTypewriterExpedition # Typewriter to T2 | Aurora Song
     - WeaponCaseShortPython45Expedition #Python to T2 | Aurora Song
     - WeaponCaseShortViper
     - WeaponCaseShortFitzExpedition
     - WeaponCaseShortWard45Expedition
     - WeaponCaseShortRevolverPirate
-    - WeaponCaseLongGestioExpedition
-    - WeaponCaseLongWeaponRifleNovaliteC1Expedition
     - WeaponCaseLongSVSExpedition
     - WeaponCaseLongKammererExpedition
-    - WeaponCaseShortLaserGunExpedition
-    - WeaponCaseLongMusketExpedition # Musket to T2 | Aurora Song
-    - WeaponCaseLongLaserCarbineExpedition # Laser Carbine to T2 | Aurora Song
+    - WeaponCaseShortBasinExpedition # moved to T2, removed burst, lowered fire rate from 6rps to 3- solid here
+    - WeaponCaseShortAdvancedLaserExpedition
     chance: 1.0
     offset: 0.0
     rarePrototypes:
     - SpawnDungeonLootGunT3
-    rareChance: 0.05
+    rareChance: 0.15 #changed
 
 #region guns T3
 - type: entity
@@ -251,14 +250,16 @@
     - WeaponCaseLongM90Expedition
     - WeaponCaseLongLecterExpedition
     - WeaponCaseLongFalchionExpedition # Aurora Weapon
-    - WeaponCaseShortBasinExpedition # Aurora Weapon
+    - WeaponCaseLongTypewriterExpedition # Typewriter to T3, why would you move this
     - WeaponCaseKasyreExpedition # Aurora Weapon
+    - WeaponCaseLongMusketExpedition # Musket to T3, long live musket
+    - WeaponCaseLongLaserCarbineExpedition # Laser Carbine to T3
     #- WeaponCaseLongHristovExpedition
     chance: 1.0
     offset: 0.0
     rarePrototypes:
     - SpawnDungeonLootGunT4
-    rareChance: 0.05
+    rareChance: 0.1 #changed
 
 #region guns T4
 - type: entity
@@ -285,10 +286,10 @@
     - WeaponCaseLongBulldog
     - WeaponCaseLongEnforcerExpedition
     - WeaponCaseShortAntiqueLaserExpedition
-    - WeaponCaseShortAdvancedLaserExpedition
-    - WeaponCaseLongXrayCannonExpedition
+    #- WeaponCaseLongXrayCannonExpedition, removed since you can fab this
     - WeaponCaseLongHristovExpedition # Hristov to T4, this thing eats walls like candy |Aurora Song
     #- WeaponCaseLongTemperatureGunExpedition | Aurora Song - Too PVP focused, not much PVE use.
+    - WeaponCaseLongEnergyGunExpedition #moved to t4, recharge rate is slow/fire rate is high, gun spawns in dungeon crates
     chance: 1.0
     offset: 0.0
     rarePrototypes:
@@ -318,9 +319,9 @@
     - WeaponCaseLongJackdaw
     - WeaponCaseLongLauncherChinaLake
     - WeaponCaseHeavyLightMachineGunL6
-    - WeaponCaseLongEnergyGunExpedition
     - WeaponCaseLongLaserCannonExpedition
     - WeaponCaseHeavyAsmgtExpeditions
+    - WeaponCaseLongEnergyLightMachineGunTurboExpedition
     chance: 1.0
     offset: 0.0
 

--- a/Resources/Prototypes/_NF/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/energy.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/energy.yml
@@ -40,6 +40,17 @@
       types:
         Heat: 16 #Damage Rebalanced | Aurora
 
+- type: entity
+  id: NFBulletLaserLMG
+  parent: NFBaseBulletLaser
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: Projectile
+    impactEffect: BulletImpactEffectOrangeDisabler
+    damage:
+      types:
+        Heat: 12 #LMG testing  
+
 # Rifles
 - type: entity
   id: NFBulletLaserHeavy

--- a/Resources/Prototypes/_NF/Entities/Objects/Weapons/Guns/Battery/base_battery_rifle_assault.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Weapons/Guns/Battery/base_battery_rifle_assault.yml
@@ -101,6 +101,24 @@
       fireCost: 80
 
 - type: entity
+  id: NFBaseWeaponEnergyLMGAssaultFireModes
+  abstract: true
+  components:
+  - type: Gun
+    examineCaliber: gun-examine-energybolt-medium
+    soundGunshot:
+      path: /Audio/Weapons/Guns/Gunshots/laser_cannon.ogg
+  - type: ProjectileBatteryAmmoProvider
+    proto: NFBulletLaserLMG
+    fireCost: 80
+  - type: BatteryWeaponFireModes
+    fireModes:
+    - proto: NFBulletLaserMedium
+      fireCost: 80
+    - proto: NFBulletDisabler
+      fireCost: 80
+
+- type: entity
   id: NFBaseWeaponEnergyRifleAssaultHitScanPulse
   abstract: true
   components:

--- a/Resources/Prototypes/_NF/Entities/Objects/Weapons/Guns/Battery/battery_rifles_assault.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Weapons/Guns/Battery/battery_rifles_assault.yml
@@ -19,7 +19,7 @@
 # Frontier
 - type: entity
   id: NFWeaponEnergyLightMachineGunTurbo
-  parent: [ NFBaseWeaponEnergyRifleAssaultFireModes, NFBaseWeaponFrameEnergyRifleAssaultCybersun ]
+  parent: [ NFBaseWeaponEnergyLMGAssaultFireModes, NFBaseWeaponFrameEnergyRifleAssaultCybersun ]
   name: turbo laser mk3
   description: |-
     A turbo laser ripped from the guardian unit. Appears to be a rather old model. Doesn't seem to be working properly. Supposedly highly illegal.
@@ -28,8 +28,8 @@
     soundGunshot:
       path: /Audio/_DV/Weapons/Guns/Gunshots/laser.ogg
   - type: ClothingSpeedModifier
-    walkModifier: 0.95
-    sprintModifier: 0.7
+    walkModifier: 1
+    sprintModifier: 1
   - type: HeldSpeedModifier
   - type: Item
     size: Ginormous
@@ -71,3 +71,7 @@
     magState: charge-level
     steps: 6
     zeroVisible: true
+  - type: BatterySelfRecharger
+    autoRecharge: true
+    autoRechargeRate: 40 # updooted for testing Default recharge rate: 1 shot per 20 seconds with 80 fireCost
+    


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR

- Adjusts weapon positions in the rarity tiers- mainly by shifting weapons available at round start to tier one, and adjusting weapon positions by usage and availability.
- Adjusts the rates at which rareChance functions per tier, starting at a 20% chance for tier 1 weapons to instead spawn as a weapon in the next tier up and reducing that chance by 5% every tier up to tier 5.
- Adds the Turbo Laser LMG to tier 5 weapon spawns.
- Tweaks the Basin Las Gun, removes burst fire mode & sets fire rate to 3.5 rps

## Why / Balance

- The spawn list at present has some weird organization and positioning for weapons better suited in other tiers. ex., round-start rifles like the novalite and gestio are moved to T1, smgs are grouped up in T3 given their lack of round-start purchase beyond the mercenary-uplink vend, similar weapon decisions.
- A huge issue frontier forks face, whether they're Frontier or Aurora, or Damnation as a sister fork of the latter, is the idea that rare things have to be obscenely rare for the gameplay to be fun; as someone with thousands of hours in that game loop across the aforementioned servers and others unmentioned, this is unwittingly predatory design, as functionally the mercenary loop becomes a string of gambling to get a rare or even semi-rare weapon to drop. Even when the weapon won't carry into the next round, a behavior persist of chasing a lucky spawn. Re-organizing the entire mercenary loop is entirely out of my ability to code- that being said, making semi rare or even rare weapons more likely to show up means less constant rushing or isolating gameplay for a dopamine hit. Rather than just coding lower tier weapons to not spawn, or removing them from the pool entirely, adjusting the rareChance means pushing the curve more in favor of tier 3 & 4 weapons across the board, and edging into tier 5 without being an entirely reliable spawn. If nothing else, I wanted this to be a design change that more respects the time of the players, and one that feeds less into baseline addictive design.

- The turbo laser is a neat and kind of funny weapon- the original prototype was unwieldy to the point of active disuse despite it's fire rate, large in part because it was slow to a fault and even slower to recharge. The adjusted prototype retains its fire rate, with reduced damage and a higher recharge rate (one pip every 2-ish seconds.) Very good for short term engagements, but lethal for the wielder if and when the charge runs out mid firefight.

- The base values for the basin las pistol's rate of fire and burst fire mode, along with its weapon case containing high capacity cells, created a situation where one could fire 4-5 bursts in 2-3 seconds and deal over 200 heat in that span of time. With a hyper cell, a common find for mercs, in 4 seconds this was over 400 heat. This's too much for a tier 3 gun, let alone a boot pistol with swappable and quickly chargeable power cells (especially now that the portable recharger can fit in duffels, backpacks, etc.)

## Technical details
Mostly files moved, prototypes made based on parents or original guns. Values adjusted after time spent using weapons in testing, & actively running numbers based on multiple in-game spawns.

rareChance adjustment made as a clever solution to the huge weight design places on T1/T2- dungeon weapon spawns (not those found in npc loot bags) have a baseline % to be upgraded a tier to a different firearm in that bracket. The default is 5% for each tier, which leads to most firearm spawns sitting squarely in T2/T3- by incrementing down from 20% to 0%, T1-T5 respectively, the spawn weights shift without removing lower tier guns entirely.

## How to test
Spawn, addgamerule your choice of uivs, roids, or test via expeds- note the gun spread, spawn the turbo laser/basin and note the gunfeel™

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**

:cl:
- add: Added the Turbo Laser to Tier 5 weapon spawns. RAT-TAT-TAT-TAT-TAT-TAT-TAT--
- remove: Removed the x-ray cannon from dungeon spawns- still available via research.
- tweak: Changed Basin Las Pistol fire rate, removed burst fire function.
- tweak: Changed weapon tier placements, & adjusted the chance for weapons to upgrade a tier when spawning. Rarer firearms should be more common as a result.

