### PR TITLE
Mob staminia-crit fix

### DIFF
--- a/Resources/Prototypes/_NF/Entities/Mobs/NPCs/mob_hostile_base.yml
+++ b/Resources/Prototypes/_NF/Entities/Mobs/NPCs/mob_hostile_base.yml
@@ -308,7 +308,7 @@
   abstract: true
   components:
   - type: Stamina
-    critThreshold: 0
+    critThreshold: 100 #Damnation; prevent permastun of fodder-classified mobs, equivalent thresh to player health.
 
 - type: entity
   id: MobStaminaSpecial


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Fodder mobs now will no longer stamina crit in one melee attack- mob npcs under the fodder type now share the same stamina health as player entities. Still stunnable, requires more risk an effort than a single punch/swing.

## Why / Balance
It's kinda busted to just rock a fast bludgeon weapon like dusters and KO most enemies in a single hit indefinitely, now this doesn't happen.

## Technical details
Changed fodder mob stamina hp from 0 to 100

## How to test
load devbox, spawn any vroid/uiv or check out any blue salvage wreck on mass scanners- try to box them and realize you have made a fatal error, or succeed and become the god of CQC

## Media
N/A

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->
N/A

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- fix: Fixed mobs entering stamina crit from a single melee attack, now basic fodder mobs have the same stamina health as you. == HEAVEN OR HELL ==, FIGHT!!!
