### PR TITLE
Accuracy + mob behavior shift

### DIFF
--- a/Content.Server/NPC/Components/NPCRangedCombatComponent.cs
+++ b/Content.Server/NPC/Components/NPCRangedCombatComponent.cs
@@ -61,4 +61,12 @@ public sealed partial class NPCRangedCombatComponent : Component
     /// </summary>
     [ViewVariables(VVAccess.ReadWrite)]
     public SoundSpecifier? SoundTargetInLOS;
+
+    // Frontier
+    /// <summary>
+    /// The chance that a shot will miss the projected path.
+    /// </summary>
+    [ViewVariables(VVAccess.ReadWrite)]
+    public float MissChance = 0.25f;
+    // End Frontier
 }

--- a/Content.Server/NPC/Systems/NPCCombatSystem.Ranged.cs
+++ b/Content.Server/NPC/Systems/NPCCombatSystem.Ranged.cs
@@ -6,6 +6,7 @@ using Content.Shared.Weapons.Ranged.Components;
 using Content.Shared.Weapons.Ranged.Events;
 using Robust.Shared.Map;
 using Robust.Shared.Physics.Components;
+using Robust.Shared.Random; //Frontier
 
 namespace Content.Server.NPC.Systems;
 
@@ -123,6 +124,13 @@ public sealed partial class NPCCombatSystem
 
             var worldPos = _transform.GetWorldPosition(xform);
             var targetPos = _transform.GetWorldPosition(targetXform);
+            
+            // Frontier -- Ranged NPC miss chance
+            if (_random.Prob(comp.MissChance))
+            {
+                targetPos = targetPos + _random.NextVector2(1.0f, 2.0f);
+            }
+            // End Frontier
 
             // We'll work out the projected spot of the target and shoot there instead of where they are.
             var distance = (targetPos - worldPos).Length();

--- a/Resources/Prototypes/Entities/Objects/Weapons/security.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/security.yml
@@ -187,7 +187,7 @@
 
 - type: entity
   name: portable flasher
-  parent: [BaseMachine, BaseC2ContrabandUnredeemable] # Frontier: BaseSecurityContraband<BaseC2ContrabandUnredeemable
+  parent: [DamnedBaseMachine, BaseC2ContrabandUnredeemable] # Damnation; base machine changed, health lowered to discourage/prevent AI cheese
   id: PortableFlasher
   description: An ultrabright flashbulb with a proximity trigger, useful for making an area security-only.
   components:
@@ -215,9 +215,9 @@
             !type:PhysShapeAabb
             bounds: "-0.15,-0.3,0.15,0.3"
           mask:
-          - MachineMask
+          - TableMask # Damnation, table > machine, anti-cheese
           layer:
-          - MachineLayer
+          - TableLayer # Damnation, table > machine, anti-cheese
           density: 380
     - type: Appearance
     - type: AnimationPlayer

--- a/Resources/Prototypes/Entities/Structures/Storage/Closets/base_structureclosets.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Closets/base_structureclosets.yml
@@ -115,7 +115,7 @@
     stateDoorClosed: generic_door
   - type: StaticPrice
     price: 50 # Frontier: 75<50 - TODO: material value rework
-  - type: Climbable # Damnation, preventing mob pathing exploits
+  #- type: Climbable # Damnation, preventing mob pathing exploits
 
 # steel closet base (that can be constructed/deconstructed)
 - type: entity

--- a/Resources/Prototypes/Entities/Structures/Storage/Closets/base_structureclosets.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Closets/base_structureclosets.yml
@@ -115,6 +115,7 @@
     stateDoorClosed: generic_door
   - type: StaticPrice
     price: 50 # Frontier: 75<50 - TODO: material value rework
+  - type: Climbable # Damnation, preventing mob pathing exploits
 
 # steel closet base (that can be constructed/deconstructed)
 - type: entity

--- a/Resources/Prototypes/Entities/Structures/Storage/Closets/base_structureclosets.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Closets/base_structureclosets.yml
@@ -54,9 +54,9 @@
           bounds: "-0.25,-0.48,0.25,0.48"
         density: 75
         mask:
-        - MachineMask
+        - TableMask # Damnationm, table > machine; anti-cheese
         layer:
-        - MachineLayer
+        - TableLayer # Damnation, table > machine see above
   - type: EntityStorage
   - type: ContainerContainer
     containers:
@@ -276,9 +276,9 @@
           bounds: "-0.25,-0.48,0.25,0.48"
         density: 350
         mask:
-        - MachineMask
+        - TableMask # Damnation, anti-cheese
         layer:
-        - MachineLayer
+        - TableLayer # Damnation, anti-cheese
   - type: EntityStorage
   - type: ContainerContainer
     containers:

--- a/Resources/Prototypes/Entities/Structures/Storage/Crates/base_structurecrates.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Crates/base_structurecrates.yml
@@ -37,7 +37,7 @@
         mask:
         - CrateMask #this is so they can go under plastic flaps
         layer:
-        - MachineLayer
+        - TableLayer # Damnation, table > machine; testing for mob pathing
   - type: EntityStorage
   - type: PlaceableSurface
     isPlaceable: false # defaults to closed.

--- a/Resources/Prototypes/Entities/Structures/Storage/Crates/base_structurecrates.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Crates/base_structurecrates.yml
@@ -97,7 +97,7 @@
       - entity_storage
   - type: RequireProjectileTarget
   - type: NFCrate # Frontier
-  - type: Climbable # Damnation
+  #- type: Climbable # Damnation
 
 - type: entity
   parent: CrateGeneric

--- a/Resources/Prototypes/Entities/Structures/Storage/Crates/base_structurecrates.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Crates/base_structurecrates.yml
@@ -97,6 +97,7 @@
       - entity_storage
   - type: RequireProjectileTarget
   - type: NFCrate # Frontier
+  - type: Climbable # Damnation
 
 - type: entity
   parent: CrateGeneric

--- a/Resources/Prototypes/Entities/Structures/Storage/Crates/crates.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Crates/crates.yml
@@ -16,7 +16,7 @@
     group: CrateSteel
   - type: RadiationBlockingContainer
     resistance: 2.5
-  - type: Climbable # Damnation, preventing mob pathing exploits
+  #- type: Climbable # Damnation, preventing mob pathing exploits
 
 - type: entity
   parent: CrateBaseWeldable

--- a/Resources/Prototypes/Entities/Structures/Storage/Crates/crates.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Crates/crates.yml
@@ -16,6 +16,7 @@
     group: CrateSteel
   - type: RadiationBlockingContainer
     resistance: 2.5
+  - type: Climbable # Damnation, preventing mob pathing exploits
 
 - type: entity
   parent: CrateBaseWeldable

--- a/Resources/Prototypes/_Damnation/Entities/Structures/Machines/base_structuremachins.yml
+++ b/Resources/Prototypes/_Damnation/Entities/Structures/Machines/base_structuremachins.yml
@@ -1,0 +1,47 @@
+- type: entity
+  abstract: true
+  parent: BaseStructure
+  id: DamnedBaseMachine
+  components:
+  - type: Animateable
+  - type: InteractionOutline
+  - type: Anchorable
+    delay: 2
+  - type: Physics
+    bodyType: Static
+  - type: Transform
+    noRot: true
+  - type: Fixtures
+    fixtures:
+      fix1:
+        shape:
+          !type:PhysShapeAabb
+          bounds: "-0.45,-0.45,0.45,0.45"
+        density: 190
+        mask:
+        - MachineMask
+        layer:
+        - MachineLayer
+  - type: Damageable
+    damageContainer: StructuralInorganic
+    damageModifierSet: StructuralMetallic
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 100
+      behaviors:
+        - !type:DoActsBehavior
+          acts: [ "Destruction" ]
+    - trigger:
+        !type:DamageTrigger
+        damage: 100
+      behaviors:
+      - !type:DoActsBehavior
+        acts: ["Destruction"]
+      - !type:PlaySoundBehavior
+        sound:
+          collection: MetalBreak
+  - type: InteractionVerbs
+    allowedVerbs:
+    - KnockOn

--- a/Resources/Prototypes/_NF/Entities/Mobs/NPCs/mob_hostile_base.yml
+++ b/Resources/Prototypes/_NF/Entities/Mobs/NPCs/mob_hostile_base.yml
@@ -378,13 +378,14 @@
        task: SimpleHostileCompound
     blackboard:
       NavClimb: !type:Bool
-        false
+        true # Damnation, prevention for mob pathing exploits.
       NavInteract: !type:Bool
         true
       NavPry: !type:Bool
         true
       NavSmash: !type:Bool # They use this option too much for my liking, but I'll keep it here as an option
         true
+  - type: Climbing # Damnation, prevention for mob pathing exploits.
 
 - type: entity
   id: MobHumanoidHostileAISimpleRanged
@@ -395,13 +396,14 @@
        task: SimpleRangedHostileCompound
     blackboard:
       NavClimb: !type:Bool
-        false
+        true # Damnation, prevention for mob pathing exploits.
       NavInteract: !type:Bool
         true
       NavPry: !type:Bool
         true
       NavSmash: !type:Bool # They use this option too much for my liking, but I'll keep it here as an option
         true
+  - type: Climbing # Damnation, prevention for mob pathing exploits
 
 - type: entity
   id: MobHumanoidHostileAIComplex
@@ -412,13 +414,14 @@
        task: SimpleHumanoidHostileCompound
     blackboard:
       NavClimb: !type:Bool
-        false
+        true # Damnation, prevention for mob pathing exploits.
       NavInteract: !type:Bool
         true
       NavPry: !type:Bool
         true
 #      NavSmash: !type:Bool # They use this option too much for my liking, but I'll keep it here as an option
 #        true
+  - type: Climbing # Damnation, prevention for mob pathing exploits
 #endregion
 
 #region NPC types

--- a/Resources/Prototypes/_NF/Entities/Mobs/NPCs/mob_hostile_mercenaries.yml
+++ b/Resources/Prototypes/_NF/Entities/Mobs/NPCs/mob_hostile_mercenaries.yml
@@ -143,7 +143,7 @@
       color: "#a9b6bd"
       shader: unshaded
   - type: BasicEntityAmmoProvider
-    proto: NFCartridgePistol35Overpressure
+    proto: NFCartridgePistol35 #Damnation; Overpressure removed
     capacity: 4
     count: 4
   - type: Gun
@@ -189,7 +189,7 @@
       color: "#a9b6bd"
       shader: unshaded
   - type: BasicEntityAmmoProvider
-    proto: NFCartridgeRifle20Overpressure
+    proto: NFCartridgeRifle20 #Damnation; Overpressure removed
     capacity: 10
     count: 10
   - type: Gun
@@ -286,7 +286,7 @@
       color: "#a9b6bd"
       shader: unshaded
   - type: BasicEntityAmmoProvider
-    proto: NFCartridgePistol35Overpressure
+    proto: NFCartridgePistol35 #Damnation; Overpressure removed
     capacity: 6
     count: 6
   - type: Gun
@@ -455,7 +455,7 @@
       color: "#a9b6bd"
       shader: unshaded
   - type: BasicEntityAmmoProvider
-    proto: NFCartridgeRifle25Overpressure
+    proto: NFCartridgeRifle25 #Damnation; Overpressure removed
     capacity: 2
     count: 2
   - type: RechargeBasicEntityAmmo


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Mob pathing returns to old status of climbing/vaulting-allowed over climbable entities to pursue a target; Lockers and crate physics-layering is now treated the same as girders, and entities can fire over the structures. 

Mercenary npcs no longer fire overpressure ammunition, and instead fire standard rounds.

## Why / Balance
Up to this point cheesing mob ai has been possible through using structure barricades that interfere with mob pathing, but allow players to fire over while taking very little to no risk- [per wizden itself](https://github.com/space-wizards/space-station-14/issues/36490) this is a known bug and is an exploit of mob behavior. 

If Den's policy overall was a concrete allowance of in-game exploits across the board, i wouldn't care much as it doesn't affect me/my playstyle doesn't rely on this sort of thing. The opening paragraph to Den's server rules outright states that use of exploits is met with appeal-only bans, and rather than dance in administrative grey areas I made these changes to better create an environment where allowed and disallowed behavior is clear cut- making for a more fair and less arbitrarily punishing experience on the whole.

## Technical details
physics and layering masks changed for parent entities of aforementioned storage entities, components added or changed to enable aforementioned behavior. npc behavior boolean toggled to "true"

## How to test
load devbox, attempt to cheese mob ai with barricades, get punished for it.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read [CONTRIBUTING.md](https://github.com/new-frontiers-14/frontier-station-14/blob/master/CONTRIBUTING.md) and and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have reviewed the [Ship Submission Guidelines](https://frontierstation.wiki.gg/wiki/Ship_Submission_Guidelines) if relevant.
- [X] I confirm that the content in this PR is my own work, and/or is properly attributed to the original author(s).
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
N/A, this is small until wizden upstream can fix mob HTN priorities/blackboard functionality.

**Changelog**
:cl:
- tweak: Changed mob behavior to prevent exploitation.
- tweak: Swapped mercenary npc overpressure ammo to standard rounds.
